### PR TITLE
Move typescript to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "description": "Romanizes Hangul (Korean) characters",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   ],
   "author": "Tyriar",
   "license": "MIT",
-  "dependencies": {
-    "typescript": "^2.0.3"
+  "devDependencies": {
+    "typescript": "^4.8.2"
   },
   "files": [
     "dist/*.js",


### PR DESCRIPTION
Hello,

Thanks for this package, it's great!

However, there's one minor problem. When you use the package you pull in typescript since it is listed as a dependency. But that's only needed when building the package. I also added the `types` field.

Hopefully you can merge this and release an update. Thank you!
